### PR TITLE
Adding support from Visual Studio Live Share

### DIFF
--- a/src/metrics/MetricsUtil.ts
+++ b/src/metrics/MetricsUtil.ts
@@ -52,34 +52,27 @@ export class MetricsUtil {
     context.subscriptions.push(disposable);
   }
 
-  get selector(): { language: string; scheme: string; }[] {
+  get selector(): { language: string; }[] {
     var tsDocSelector = {
-      language: 'typescript',
-      scheme: 'file'
+      language: 'typescript'
     };
     var jsDocSelector = {
-      language: 'javascript',
-      scheme: 'file'
+      language: 'javascript'
     };
     var jsxDocSelector = {
-      language: 'javascriptreact',
-      scheme: 'file'
+      language: 'javascriptreact'
     };
     var tsxDocSelector = {
-      language: 'typescriptreact',
-      scheme: 'file'
+      language: 'typescriptreact'
     };
     var luaDocSelector = {
-      language: 'lua',
-      scheme: 'file'
+      language: 'lua'
     };
     var vueDocSelector = {
-      language: 'vue',
-      scheme: 'file'
+      language: 'vue'
     };
     var htmlDocSelector = {
-      language: 'html',
-      scheme: 'file'
+      language: 'html'
     };
     return [tsDocSelector, jsDocSelector, jsxDocSelector, tsxDocSelector, luaDocSelector, vueDocSelector, htmlDocSelector];
   }


### PR DESCRIPTION
This PR adds support for [Visual Studio Live Share](http://aka.ms/vsls), which allows developers who have this extension installed, to continue seeing code complexity metrics while collaborating on someone else's project. On the guest's side, files use the `vsls` scheme, which prevents this extension from displaying metrics, despite the fact that it would otherwise work. Note that the green/yellow/red decorator already displays in all scheme types, so this change simply allows the CodeLens to show as well. For example, this is what the experience looks like for a Live Share guest before this PR:

<img width="407" alt="screen shot 2018-02-24 at 8 05 38 pm" src="https://user-images.githubusercontent.com/116461/36638084-7cce9fd6-199f-11e8-9f1b-c6d5037806ca.png">

And this is what the experience looks like after the PR. Notice that both the guest and the host of the collaboration session are able to view metrics, which is awesome, since the "guest" might want to see this metadata and recommend some refactoring to the developer he/she is helping:

<img width="975" alt="screen shot 2018-02-24 at 8 07 10 pm" src="https://user-images.githubusercontent.com/116461/36638082-705d37d0-199f-11e8-915e-a3826abc7a58.png">

As a side effect of removing the scheme in general, the complexity metrics would also begin showing up in "untitled" files (e.g. unsaved/in-memory documents), which seems reasonable to me, since the red/green/yellow decorator would already show up, and the CodeLens is already filtered by supported languages.

// CC @kisstkondoros