### PR TITLE
Add DecorationTemplate configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,12 @@
           "description": "A flag which indicates whether code metrics are shown as inline decoration",
           "type": "boolean"
         },
+        "codemetrics.basics.DecorationTemplate": {
+          "scope": "resource",
+          "default": "<svg xmlns='http://www.w3.org/2000/svg' width='{{size}}px' height='{{size}}px' viewbox='0 0 {{size}} {{size}}'><rect width='{{size}}' height='{{size}}' style='fill:{{color}};stroke-width:1;stroke:#fff'/></svg>",
+          "description": "A flag which indicates whether code metrics are shown as inline decoration",
+          "type": "string"
+        },
         "codemetrics.basics.CodeLensEnabled": {
           "scope": "resource",
           "default": true,

--- a/src/metrics/common/VSCodeMetricsConfiguration.ts
+++ b/src/metrics/common/VSCodeMetricsConfiguration.ts
@@ -11,6 +11,7 @@ const VSCodeMetricsConfigurationDefaults = {
     EnabledForVue: true,
     EnabledForHTML: true,
     DecorationModeEnabled: true,
+    DecorationTemplate: "<svg xmlns='http://www.w3.org/2000/svg' width='{{size}}px' height='{{size}}px' viewbox='0 0 {{size}} {{size}}'><rect width='{{size}}' height='{{size}}' style='fill:{{color}};stroke-width:1;stroke:#fff'/></svg>",
     OverviewRulerModeEnabled: true,
     CodeLensEnabled: true,
     DiagnosticsEnabled: false,


### PR DESCRIPTION
Hi,

I didn't like those big rectangle decorators, so I added a configuration option to customize the decorator SVG.

That way you can override the default SVG like this:

```json
{
    "codemetrics.basics.DecorationTemplate": "<svg xmlns='http://www.w3.org/2000/svg' width='{{size}}px' height='{{size}}px' viewbox='0 0 {{size}} {{size}}'><circle r='30%' cx='30%' cy='70%' style='fill:{{color}}'/></svg>"
}
```

And get this...

![image](https://user-images.githubusercontent.com/875017/54827258-d8b25900-4cb1-11e9-98f6-d6ef34b56d0c.png)
